### PR TITLE
fix: switch to official python base image over bitnami

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG PYTHON_VERSION=3.12
 
-FROM bitnami/python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}
 RUN apt update && apt upgrade -y \
   && apt install curl -y \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# What this PR is

Switches to the official python base image over `bitnami` after their access changes
